### PR TITLE
Fix invalid HTML tags

### DIFF
--- a/Chapters/solarity_chapter1.html
+++ b/Chapters/solarity_chapter1.html
@@ -56,9 +56,9 @@
 <p><span class="comment">The sentence came out spontaneously, and somehow I had to laugh.</span> <span class="spoken philipp">„War auch klar...Als ob mein Tarif galaktisch funktioniert.“</span></p>
 <p class="translation philipp" style="margin-left: 450px;">//Figures...Like if my carrier works across galaxies.//</p>
 <p>A quiet, genuine, unexpected laugh. Dumb. But good. I looked at the battery level: 90%. Not bad. Without much thought, I immediately turned on ultra power-saving mode. You never know. Maybe... maybe I'll need it here. For what? No idea. But it felt right. I carefully put the smartphone back in my pocket and then reached for my wallet. A smart wallet. Minimalist. Black. Not some flashy thing with a hundred cards and blinking flaps like others carry around. Simple. Functional. Mine. I opened it. Just a few cards. And in the middle: my ID pass. I pulled it out. Looked at it for a long time.</p>
-<p><span class="spoken philipp">"Philipp"</p>
+<p><span class="spoken philipp">"Philipp"</span></p>
 <p>Yes. That’s me. I said it again internally. As confirmation. As an anchor. Because I realized I was starting to doubt myself. Not just because of this strange world, but because my memory… had holes. I had memories. But patchy. The last month? Gone. Simply erased. Something must be connected to my fall, I thought. Then I felt it. Something was in my head. Foreign thoughts. Thoughts that didn’t sound like mine—but still felt right. I didn’t know what they meant. Or where they came from. But something deep inside me told me they were important. Maybe even helpful. This thought alone made me shake my head in disbelief—several times, almost violently. What was happening to me? I raised my hands and lightly slapped my cheeks. A final wake-up. A call to myself.</p>
-<p><span class="spoken philipp">„Schluss damit.“</p>
+<p><span class="spoken philipp">„Schluss damit.“</span></p>
 <p class="translation philipp">//Enough of this.//</p>
 <p><span class="comment">I put the wallet back in my pocket.</span> <span class="spoken philipp">"Ich muss…ich muss herausfinden, wo ich bin. Was das hier ist. Und… vielleicht auch, wie ich wieder nach Hause komme."</span></p>
 <p class="translation philipp">//I have to...I have to find out where I am. What this place is. And... maybe also, how I get back home.//</p>
@@ -66,7 +66,6 @@
 <p><span class="comment">The thought roared through my mind, louder than I could have spoken it.</span> <span class="spoken philipp">„VERDAMMT!“</span></p>
 <p class="translation philipp" style="margin-left: 480px;">//DAMN IT!//</p>
 <p>It burned in my chest. Then, like a strike to my consciousness: the beach below. The state of the loungers. The sand that had overgrown everything. The kilometer-long dried-out bay, whose water had receded blood-red to the horizon. This was not a place teeming with life. This was a place that had long been abandoned. The realization crawled up inside me—ice cold and silent. I would meet no one here. Maybe...not for a very long time. At the top of the stairs, I stopped. I overlooked the city—and now saw it clearer than ever: Everything was far more desolate than it had first appeared.</p>
-</body>
 <!-- Kapitel-Navigation unten -->
 <div class="chapter-buttons">
   <a href="../index.html">Home</a>

--- a/Chapters/solarity_chapter2.html
+++ b/Chapters/solarity_chapter2.html
@@ -46,10 +46,10 @@
   <p class="translation philipp">//Of course//</p>
   <p><span class="comment">I muttered dryly.</span> <span class="spoken philipp">„Warum sollte etwas hier einfach sein…“</span></p>
   <p class="translation philipp">//Why would anything here be easy…//</p>
-  <p><span class="comment">I tentatively tapped one of the symbols. It lit up briefly – then… nothing. No reaction. I tried another. And another. Stillness.</p>
+  <p><span class="comment">I tentatively tapped one of the symbols. It lit up briefly – then… nothing. No reaction. I tried another. And another. Stillness.</span></p>
   <p><span class="spoken philipp">„Tja… wäre ja zu schön gewesen.“</span></p>
   <p class="translation philipp">//Well…that would have been too good.//</p>
-  <p><span class="comment">I still stared at the display. The shapes. The patterns. Something about it seemed… familiar. I frowned, stepped closer.</p>
+  <p><span class="comment">I still stared at the display. The shapes. The patterns. Something about it seemed… familiar. I frowned, stepped closer.</span></p>
   <p><span class="spoken philipp">„Moment mal…“</span></p>
   <p class="translation philipp">//Wait a minute…//</p>
   <p><span class="comment">I leaned forward. Looked more closely.</span> <span class="spoken philipp">„Ist das nicht…Kanji?“</span></p>
@@ -63,15 +63,15 @@
   <p>A word appeared. <span class="spoken friendly">//Chips//</span></p>
   <p><span class="comment">I stared at it.</span> <span class="spoken philipp">„CHIPS!? HIER!? HAH!“</span></p>
   <p class="translation philipp">//CHIPS!? HERE!? HAH!//</p>
-  <p><span class="comment">I started to laugh. First quietly, then louder. It wasn't healthy, controlled humor – it was the madness of a desperate person who had found a bag of chips in the middle of a post-apocalyptic alien mall.</p>
-  <p><span class="spoken philipp">„Keine Lebewesen, keine Hilfe – aber CHIPS gibt es noch!“<</span></p>
+  <p><span class='comment'>I started to laugh. First quietly, then louder. It wasn't healthy, controlled humor – it was the madness of a desperate person who had found a bag of chips in the middle of a post-apocalyptic alien mall.</span></p>
+  <p><span class="spoken philipp">„Keine Lebewesen, keine Hilfe – aber CHIPS gibt es noch!“</span></p>
   <p class="translation philipp">//No living beings, no help – but there are still CHIPS!//</p>
-  <p><span class="comment">More words appeared as I scanned the display.</p>
+  <p><span class="comment">More words appeared as I scanned the display.</span></p>
   <p><span class="spoken philipp">„Nudeln. Energieriegel. Zitronenwasser. Tofu-Teriyaki-Snack? Irgendwas mit Algenextrakt…“</span></p>
   <p class="translation philipp">//Noodles. Energy bar. Lemon water. Tofu Teriyaki snack? Something with algae extract…//</p>
   <p><span class="comment">I shook my head, grinning.</span> <span class="spoken philipp">„Klingt…essbar.“</span></p>
   <p class="translation philipp">//Sounds…edible//</p>
-  <p><span class="comment">Then a thought occurred to me. I took a step back, crossed my arms.</p>
+  <p><span class='comment'>Then a thought occurred to me. I took a step back, crossed my arms.</span></p>
   <p><span class="spoken philipp">„Moment mal… Ist das Zeug da drinnen überhaupt noch gut?"</span></p>
   <p class="translation philipp">//Wait a minute… Is that stuff still good in there?//</p>
   <p><span class="comment">I chuckled.</span> <span class="spoken philipp">„Nur ein Weg, das rauszufinden.“</span></p>
@@ -79,9 +79,9 @@
   <p>I tapped the button next to Chips. Then on Confirm. A moment of silence. Then the screen flickered – and a new message appeared.</p>
   <p><span class="spoken friendly">//Cost: 200 Credits//</span></p>
   <p>I stared at it. For a few seconds, I said nothing.</p>
-  <p><span class="comment">Then:</span> <span class="spoken philipp">„Ist das dein Ernst…?“</p>
+  <p><span class="comment">Then:</span> <span class="spoken philipp">„Ist das dein Ernst…?“</span></p>
   <p class="translation philipp">//Are you serious…?//</p>
-  <p><span class="comment">My voice trembled.</span> <span class="spoken philipp">„DEIN SCHEIß ERNST!?“</p>
+  <p><span class="comment">My voice trembled.</span> <span class="spoken philipp">„DEIN SCHEIß ERNST!?“</span></p>
   <p class="translation philipp"><strong>//ARE YOU FUCKING SERIOUS!?//</strong></p>
   <p>The scream thundered out of me like an explosion. It echoed through the hall, vibrated in the glass remnants and shelves, bounced off walls like the outburst of a desperate god. And then I completely lost my patience. I kicked. Hard. Directly against the vending machine.</p>
   <p><span class="spoken philipp"><strong>„ICH. WERDE. NICHT. WEGEN. SCHEIß. 200. CREDITS. VERHUNGERN!!!“</strong></span></p>
@@ -166,7 +166,6 @@
   <p><span class="comment">I mumbled.</span> <span class="spoken philipp">„Wenn das hier ein verdammter Wahnsinn ist, dann will ich wenigstens wissen, wovon ich verrückt werde.“</span></p>
   <p class="translation philipp">//If this is damn madness, then at least I want to know what I'm going crazy from//</p>
   <p>I took a step forward. Then another. And began to search systematically. Everything I could grasp. Everything I could decipher. I rummaged through the shelves. Opened old archives. Compared characters. Photographed. Translated. Because either I had long since gone mad… Or something incredible had happened. Something that no longer separated reality and fiction. Something that connected everything. I wanted to know. I had to know. And this library was my key.</p>
-</body>
 <!-- Kapitel-Navigation unten -->
 <div class="chapter-buttons">
   <a href="solarity_chapter1.html">« Chapter 1</a>

--- a/index.html
+++ b/index.html
@@ -20,7 +20,6 @@
   <h2 class="subtitle">A Reality Bending / Multiversal Fan Project</h2>
 
   <!-- Coverbild -->
- <body class="index-page">
 
   <!-- Disclaimer -->
 <footer>


### PR DESCRIPTION
## Summary
- remove duplicate `<body>` tag from `index.html`
- fix missing `</span>` tags and remove stray closing tags in chapter pages
- ensure closing tags appear in the right order

## Testing
- `tidy -q -e index.html`
- `tidy -q -e Chapters/solarity_chapter1.html`
- `tidy -q -e Chapters/solarity_chapter2.html`


------
https://chatgpt.com/codex/tasks/task_e_684151b79364832d9a52ce4c6fd376b2