### PR TITLE
Reduce gap between spoken text and translations

### DIFF
--- a/Chapters/chapter.css
+++ b/Chapters/chapter.css
@@ -72,7 +72,7 @@ span.spoken {
 }
 
 p.spoken {
-  margin-bottom: 2px;
+  margin-bottom: 1px;
 }
 
 span.translation {
@@ -81,7 +81,7 @@ span.translation {
 }
 
 p.translation {
-  margin-top: 2px;
+  margin-top: 1px;
   margin-bottom: 16px;
   margin-left: 0;
   font-size: 0.95em;


### PR DESCRIPTION
## Summary
- tweak dialog CSS for tighter spacing

## Testing
- `npm test` *(fails: missing `package.json`)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684155398620832da7c3a78cf1feb612